### PR TITLE
Add github.io 404 page

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,0 +1,11 @@
+---
+layout: default
+permalink: /404.html
+---
+[↩ Main Page](/)
+
+# **404**
+
+File not found!
+
+[Return to Main Page](/)

--- a/404.md
+++ b/404.md
@@ -2,10 +2,10 @@
 layout: default
 permalink: /404.html
 ---
-[↩ Main Page](/)
+[↩ Main Page](/index.md)
 
 # **404**
 
 File not found!
 
-[Return to Main Page](/)
+[Return to Main Page](/index.md)


### PR DESCRIPTION
Add a 404 error page to redirect 'not found' errors to the main page instead of the generic GitHub error page.